### PR TITLE
Fix links on main documentation page

### DIFF
--- a/src/docs/README.md
+++ b/src/docs/README.md
@@ -5,6 +5,6 @@ Welcome to the skidfuscator-java-obfuscator wiki!
 You wish we had much to talk about. But we don't. Ha
 
 # Table of Contents
-1. [Exclusions](/exclusion)
-2. [Libraries](/libraries)
-3. [Transformers](/transformers)
+1. [Exclusions](/docs/exclusion.html)
+2. [Libraries](/docs/libraries.html)
+3. [Transformers](/docs/transformers.html)


### PR DESCRIPTION
Probably not the way you're supposed to deal with links? but the original was not working so this is my solution